### PR TITLE
Fix awkward spaces between example badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,9 @@ You can align the badges by wrapping the seconds in a paragraph tag and setting 
 </p>
 ```
 <p align="left">
- <a href="#">
-    <img src="help/Badge1.svg" alt="blogger" style="vertical-align:top; margin:6px 4px">
-  </a>  
- <a href="#">
-    <img src="help/Badge2.svg" alt="blogger" style="vertical-align:top; margin:6px 4px">
-  </a>  
- <a href="#">
-    <img src="help/Badge3.svg" alt="blogger" style="vertical-align:top; margin:6px 4px">
-  </a>  
+ <a href="#"><img src="help/Badge1.svg" alt="blogger" style="vertical-align:top; margin:6px 4px"></a>  
+ <a href="#"><img src="help/Badge2.svg" alt="blogger" style="vertical-align:top; margin:6px 4px"></a>  
+ <a href="#"><img src="help/Badge3.svg" alt="blogger" style="vertical-align:top; margin:6px 4px"></a>  
 </p>
 
 #### Center Alignment
@@ -66,15 +60,9 @@ You can align the badges by wrapping the seconds in a paragraph tag and setting 
 </p>
 ```
 <p align="center">
-  <a href="#">
-    <img src="help/Badge1.svg" alt="blogger" style="vertical-align:top; margin:6px 4px">
-  </a>  
- <a href="#">
-    <img src="help/Badge2.svg" alt="blogger" style="vertical-align:top; margin:6px 4px">
-  </a>  
- <a href="#">
-    <img src="help/Badge3.svg" alt="blogger" style="vertical-align:top; margin:6px 4px">
-  </a>  
+  <a href="#"><img src="help/Badge1.svg" alt="blogger" style="vertical-align:top; margin:6px 4px"></a>  
+ <a href="#"><img src="help/Badge2.svg" alt="blogger" style="vertical-align:top; margin:6px 4px"></a>  
+ <a href="#"><img src="help/Badge3.svg" alt="blogger" style="vertical-align:top; margin:6px 4px"></a>  
 </p>
 
 #### Right Alignment
@@ -84,15 +72,9 @@ You can align the badges by wrapping the seconds in a paragraph tag and setting 
 </p>
 ```
 <p align="right">
-  <a href="#">
-    <img src="help/Badge1.svg" alt="blogger" style="vertical-align:top; margin:6px 4px">
-  </a>  
- <a href="#">
-    <img src="help/Badge2.svg" alt="blogger" style="vertical-align:top; margin:6px 4px">
-  </a>  
- <a href="#">
-    <img src="help/Badge3.svg" alt="blogger" style="vertical-align:top; margin:6px 4px">
-  </a>  
+  <a href="#"><img src="help/Badge1.svg" alt="blogger" style="vertical-align:top; margin:6px 4px"></a>  
+ <a href="#"><img src="help/Badge2.svg" alt="blogger" style="vertical-align:top; margin:6px 4px"></a>  
+ <a href="#"><img src="help/Badge3.svg" alt="blogger" style="vertical-align:top; margin:6px 4px"></a>  
 </p>
 
 ---


### PR DESCRIPTION
Squish image links down to 1 line each to remove empty hypertext between them.